### PR TITLE
Loading event: add reference to transition promise

### DIFF
--- a/source/routing/loading-and-error-substates.md
+++ b/source/routing/loading-and-error-substates.md
@@ -92,6 +92,23 @@ If the `loading` handler is not defined at the specific route,
 the event will continue to bubble above a transition's parent
 route, providing the `application` route the opportunity to manage it.
 
+When using the `loading` handler, we can make use of the transition promise to know when the loading event is over:
+
+```app/routes/foo-slow-model.js
+export default Ember.Route.extend({
+  ...
+  actions: {
+    loading(transition, originRoute) {
+      let controller = this.controllerFor('foo');
+      controller.set('currentlyLoading', true);
+      transition.promise.finally(function() {
+          controller.set('currentlyLoading', false);
+      });
+    }
+  }
+});
+```
+
 ## `error` substates
 
 Ember provides an analogous approach to `loading` substates in


### PR DESCRIPTION
Add an example for using the transition promise to effectively use the `loading` event handler
